### PR TITLE
Improve PerfQuery accuracy

### DIFF
--- a/Source/Core/VideoBackends/D3D/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.cpp
@@ -86,7 +86,7 @@ u32 PerfQuery::GetQueryResult(PerfQueryType type)
   else if (type == PQ_EFB_COPY_CLOCKS)
     result = m_results[PQG_EFB_COPY_CLOCKS];
 
-  return result / 4;
+  return result;
 }
 
 void PerfQuery::FlushOne()
@@ -102,6 +102,8 @@ void PerfQuery::FlushOne()
   }
 
   // NOTE: Reported pixel metrics should be referenced to native resolution
+  // TODO: Dropping the lower 2 bits from this count should be closer to actual
+  // hardware behavior when drawing triangles.
   m_results[entry.query_type] += (u32)(result * EFB_WIDTH / g_renderer->GetTargetWidth() *
                                        EFB_HEIGHT / g_renderer->GetTargetHeight());
 

--- a/Source/Core/VideoBackends/D3D12/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D12/PerfQuery.cpp
@@ -98,7 +98,7 @@ u32 PerfQuery::GetQueryResult(PerfQueryType type)
   else if (type == PQ_EFB_COPY_CLOCKS)
     result = m_results[PQG_EFB_COPY_CLOCKS];
 
-  return result / 4;
+  return result;
 }
 
 void PerfQuery::FlushOne()
@@ -126,6 +126,8 @@ void PerfQuery::FlushOne()
   m_query_readback_buffer->Unmap(0, &write_range);
 
   // NOTE: Reported pixel metrics should be referenced to native resolution
+  // TODO: Dropping the lower 2 bits from this count should be closer to actual
+  // hardware behavior when drawing triangles.
   m_results[entry.query_type] += (u32)(result * EFB_WIDTH / g_renderer->GetTargetWidth() *
                                        EFB_HEIGHT / g_renderer->GetTargetHeight());
 
@@ -179,6 +181,8 @@ void PerfQuery::FlushResults()
            sizeof(UINT64));
 
     // NOTE: Reported pixel metrics should be referenced to native resolution
+    // TODO: Dropping the lower 2 bits from this count should be closer to actual
+    // hardware behavior when drawing triangles.
     m_results[entry.query_type] += (u32)(result * EFB_WIDTH / g_renderer->GetTargetWidth() *
                                          EFB_HEIGHT / g_renderer->GetTargetHeight());
 


### PR DESCRIPTION
In TimeSplitters: Future Perfect, PerfQuery is used to detect
the visibility of lights and draw coronas. 25 points are drawn
for each light. However, the returned count was incorrectly
being divided by four leading to dim coronas.

Using 4x antialiasing was a workaround because of a bug where
antialiasing multiplied the PerfQuery results. This commit
fixes that bug too (but only for OpenGL).