### PR TITLE
Support true immediate independent flip in D3D12 backend.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ Dolphin can only be installed on devices that satisfy the above requirements. At
 Use the solution file `Source/dolphin-emu.sln` to build Dolphin on Windows.
 Visual Studio 2015 Update 2 is a hard requirement. Other compilers might be
 able to build Dolphin on Windows but have not been tested and are not
-recommended to be used. Git and Windows 10 SDK 10.0.10586.0 must be installed.
+recommended to be used. Git and Windows 10 SDK 10.0.14393.0 must be installed.
 
 An installer can be created by using the `Installer.nsi` script in the
 Installer directory. This will require the Nullsoft Scriptable Install System

--- a/Source/Core/VideoBackends/D3D12/D3D12.vcxproj
+++ b/Source/Core/VideoBackends/D3D12/D3D12.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{570215B7-E32F-4438-95AE-C8D955F9FCA3}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/Source/Core/VideoBackends/D3D12/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DBase.cpp
@@ -328,7 +328,7 @@ HRESULT Create(HWND wnd)
   swap_chain_desc.SampleDesc.Quality = 0;
   swap_chain_desc.Windowed = true;
   swap_chain_desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
-  swap_chain_desc.Flags = 0;
+  swap_chain_desc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
 
   swap_chain_desc.BufferDesc.Width = s_xres;
   swap_chain_desc.BufferDesc.Height = s_yres;
@@ -766,7 +766,8 @@ void Reset()
   s_yres = client.bottom - client.top;
 
   CheckHR(s_swap_chain->ResizeBuffers(SWAP_CHAIN_BUFFER_COUNT, s_xres, s_yres,
-                                      DXGI_FORMAT_R8G8B8A8_UNORM, 0));
+                                      DXGI_FORMAT_R8G8B8A8_UNORM,
+                                      DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING));
 
   // recreate back buffer textures
 
@@ -842,7 +843,7 @@ void Present()
       static_cast<double>(current_qpc.QuadPart - s_last_present_qpc.QuadPart) /
       s_qpc_frequency.QuadPart;
 
-  unsigned int present_flags = 0;
+  unsigned int present_flags = g_ActiveConfig.IsVSync() ? 0 : DXGI_PRESENT_ALLOW_TEARING;
 
   if (g_ActiveConfig.IsVSync() == false &&
       time_elapsed_since_last_present < (1.0 / static_cast<double>(s_monitor_refresh_rate)) / 2.0)


### PR DESCRIPTION
D3D12 fullscreen will no longer be vsynced when the option is disabled.